### PR TITLE
fix: encode message header key to bytes

### DIFF
--- a/asgi_request_id/middleware.py
+++ b/asgi_request_id/middleware.py
@@ -34,7 +34,7 @@ class RequestIDMiddleware:
         def send_wrapper(response):
             response_headers = response.get("headers")
             if response_headers:
-                response["headers"].append((self.outgoing_id_header, request_id.encode()))
+                response["headers"].append((self.outgoing_id_header.encode(), request_id.encode()))
             return send(response)
 
         if scope["type"] == "http":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asgi-request-id"
-version = "0.2.0"
+version = "0.2.1"
 description = "ASGI request id middleware"
 authors = ["Arni Inaba Kjartansson <arni@inaba.is>"]
 maintainers = ["Fabio Greco <fabio.greco.github@gmail.com>"]


### PR DESCRIPTION
According to the ASGI spec the headers should be `(Iterable[[byte string, byte string]])`